### PR TITLE
DOC: Fix IOFF bundle acronym case: capitalize all initials

### DIFF
--- a/Tracts-in-ORG-800FC-100HCP.md
+++ b/Tracts-in-ORG-800FC-100HCP.md
@@ -7,7 +7,7 @@ Overall, there are 58 deep white matter fiber tracts from the association, cereb
     * cingulum bundle (CB) – LR
     * extreme capsule (EmC) – LR
     * inferior longitudinal fasciculus (ILF) – LR
-    * inferior occipito-frontal fasciculus (IoFF) – LR
+    * inferior occipito-frontal fasciculus (IOFF) – LR
     * middle longitudinal fasciculus (MdLF) – LR
     * superior longitudinal fasciculus I (SLF I) – LR
     * superior longitudinal fasciculus II (SLF II) – LR


### PR DESCRIPTION
Fix IOFF bundle acronym case: capitalize all initials.

Match the case used in the data files hosted in this repository and in
the `zenodo` files, and across the rest of the `SlicerDMRI` organization
repositories.